### PR TITLE
OpenVX 1.3.1 header file updates

### DIFF
--- a/include/VX/vx_khr_bidirectional_parameters.h
+++ b/include/VX/vx_khr_bidirectional_parameters.h
@@ -43,6 +43,8 @@ enum vx_bidirectional_enum_e
 };
 
 #ifdef OPENVX_KHR_BIDIRECTIONAL_OPTIONAL_KERNELS
+
+#ifndef VX_VERSION_1_1
 /*! \brief [Graph] Creates an accumulate node.
  * \param [in] graph The reference to the graph.
  * \param [in] input The input <tt>\ref VX_DF_IMAGE_U8</tt> image.
@@ -52,6 +54,7 @@ enum vx_bidirectional_enum_e
  * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>  
  */
 VX_API_ENTRY vx_node VX_API_CALL vxAccumulateImageNode(vx_graph graph, vx_image input, vx_image accum);
+#endif
 
 /*! \brief [Graph] Creates a weighted accumulate node.
  * \param [in] graph The reference to the graph.

--- a/include/VX/vx_khr_swap_move.h
+++ b/include/VX/vx_khr_swap_move.h
@@ -21,6 +21,7 @@
 #include <VX/vx.h>
 
 /* NOTE: The bidirectional parameters extension is required for the swap_move extension */
+#define OPENVX_KHR_SWAP_MOVE  "vx_khr_swap_move"
 
 #ifdef  __cplusplus
 extern "C" {


### PR DESCRIPTION
added missing `VX_VERSION_1_1` and `OPENVX_KHR_SWAP_MOVE` in header files